### PR TITLE
dlv can get homepath from env var to avoid slow startup

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -307,9 +307,12 @@ func hasOldConfig() (bool, error) {
 	if os.Getenv("XDG_CONFIG_HOME") == "" && runtime.GOOS != "linux" {
 		return false, nil
 	}
-
-	userHomeDir := getUserHomeDir()
-
+	var userHomeDir string
+	if os.Getenv("HOMEDIR") != "" {
+		userHomeDir = os.Getenv("HOMEDIR")
+	} else {
+		userHomeDir = getUserHomeDir()
+	}
 	o := path.Join(userHomeDir, configDirHidden, configFile)
 	_, err := os.Stat(o)
 	if err != nil {


### PR DESCRIPTION
https://github.com/go-delve/delve/issues/2072